### PR TITLE
Nue Clear English translation

### DIFF
--- a/Taskie/App.xaml
+++ b/Taskie/App.xaml
@@ -2,8 +2,8 @@
     x:Class="Taskie.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Taskie"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:Taskie">
     <Application.Resources>
         <controls:XamlControlsResources>
             <controls:XamlControlsResources.MergedDictionaries>
@@ -19,10 +19,13 @@
                             <Color x:Key="BGColor">#000</Color>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
-                    <Style x:Key="SearchStyle" TargetType="AutoSuggestBox" BasedOn="{StaticResource DefaultAutoSuggestBoxStyle}">
+                    <Style
+                        x:Key="SearchStyle"
+                        BasedOn="{StaticResource DefaultAutoSuggestBoxStyle}"
+                        TargetType="AutoSuggestBox">
                         <Style.Setters>
-                            <Setter Property="VerticalContentAlignment" Value="Center"/>
-                            <Setter Property="BorderBrush" Value="{ThemeResource ControlElevationBorderBrush}"/>
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Setter Property="BorderBrush" Value="{ThemeResource ControlElevationBorderBrush}" />
                             <Setter Property="QueryIcon">
                                 <Setter.Value>
                                     <FontIcon Glyph="&#xE721;" />

--- a/Taskie/SettingsPages/AppearancePage.xaml
+++ b/Taskie/SettingsPages/AppearancePage.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Taskie.SettingsPages"
+    xmlns:models="using:TaskieLib.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -20,6 +21,13 @@
                 <RadioButton x:Uid="LightThemeRadio" x:Name="LightRadio" Tag="Light" Checked="RadioButton_StateChanged" Unchecked="RadioButton_StateChanged"/>
                 <RadioButton x:Uid="DarkThemeRadio" x:Name="DarkRadio" Tag="Dark" Checked="RadioButton_StateChanged" Unchecked="RadioButton_StateChanged"/>
                 <RadioButton x:Uid="SystemThemeRadio" x:Name="SystemRadio" Tag="System" Checked="RadioButton_StateChanged" Unchecked="RadioButton_StateChanged"></RadioButton>
+                <ComboBox ItemsSource="{x:Bind models:Langwaj.Supported}" SelectedItem="{x:Bind models:Langwaj.Override, Mode=TwoWay}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:Langwaj">
+                            <TextBlock Text="{x:Bind Name}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <TextBlock FontSize="13" Opacity=".7" TextWrapping="Wrap" Margin="1,10,5,10" x:Uid="RestartWarning"/>
                 <Button x:Name="RestartButton" Click="RestartButton_Click">
                     <StackPanel Orientation="Horizontal" Margin="0,0,20,0">

--- a/Taskie/Strings/en-IN/Resources.resw
+++ b/Taskie/Strings/en-IN/Resources.resw
@@ -118,195 +118,96 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutApp.Text" xml:space="preserve">
-    <value>Thanks for supporting me. Taskie is one of my first projects, which I poured a lot of love into. You can check out my other projects on GitHub. I hope you like Taskie. Best wishes from Poland!</value>
-  </data>
-  <data name="AboutCategory" xml:space="preserve">
-    <value>About</value>
-  </data>
-  <data name="AddTaskBox.PlaceholderText" xml:space="preserve">
-    <value>Add task...</value>
+    <value>Thanks for supporting me. Taskie is one of my first projects, which I poar'd a lot of luv into. You can check out my udher projects on GitHub. I hope you like Taskie. Best wishes from Poland!</value>
   </data>
   <data name="AdvertTag.Text" xml:space="preserve">
-    <value>Your quick and private task companion.</value>
-  </data>
-  <data name="AdvertUWPTag.Text" xml:space="preserve">
-    <value>Made with UWP.</value>
+    <value>Your quick and privat task compänion.</value>
   </data>
   <data name="AppearanceCategory" xml:space="preserve">
-    <value>Appearance</value>
+    <value>Apearance</value>
   </data>
   <data name="AppearanceText.Text" xml:space="preserve">
-    <value>Appearance</value>
+    <value>Apearance</value>
   </data>
   <data name="AppThemeSubText.Text" xml:space="preserve">
-    <value>Change app theme</value>
-  </data>
-  <data name="AppThemeText.Text" xml:space="preserve">
-    <value>Theme</value>
+    <value>Chainj app theme</value>
   </data>
   <data name="AuthDescription.Text" xml:space="preserve">
-    <value>Make the app ask for your password/pin/biometrics via Windows Hello. This option may not be available if your computer doesn't have a password or you haven't purchased Taskie Pro.</value>
+    <value>Make the app ask for your passwerd/pin/biomëtrics via Windows Hello. This option may not be available if your computer dusn't have a passwerd or you haven't pürchuss'd Taskie Pro.</value>
   </data>
   <data name="AuthDisabledDescription" xml:space="preserve">
-    <value>Removed biometrics or password, your administrator removed the option, you refunded Taskie Pro or something else happened. Check Windows Settings or the Microsoft Store.</value>
+    <value>Remoov'd biomëtrics or passwerd, your ädministrater remoov'd the option, you refünded Taskie Pro or something else happen'd. Check Windows Settings or the Microsoft Store.</value>
   </data>
   <data name="AuthDisabledTitle" xml:space="preserve">
-    <value>Authentication has been turned off.</value>
+    <value>Authëntication has been turn'd off.</value>
   </data>
   <data name="AuthText.Text" xml:space="preserve">
-    <value>Use authentication</value>
-  </data>
-  <data name="BackupHeader.Text" xml:space="preserve">
-    <value>Back up</value>
-  </data>
-  <data name="BackupsCategory" xml:space="preserve">
-    <value>Backups</value>
-  </data>
-  <data name="BackupsText.Text" xml:space="preserve">
-    <value>Backups</value>
+    <value>Uze authëntication</value>
   </data>
   <data name="BackupText.Text" xml:space="preserve">
-    <value>Export all lists with one click below. To export one list, right-click it and choose Export or use the three-dot menu after opening it.</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="CompactOverlayButton.Text" xml:space="preserve">
-    <value>Open Taskie Mini</value>
-  </data>
-  <data name="DarkThemeRadio.Content" xml:space="preserve">
-    <value>Dark</value>
-  </data>
-  <data name="DeleteList.Text" xml:space="preserve">
-    <value>Delete list</value>
-  </data>
-  <data name="DeleteTask.Text" xml:space="preserve">
-    <value>Delete task</value>
-  </data>
-  <data name="ExportButton.Text" xml:space="preserve">
-    <value>Export</value>
-  </data>
-  <data name="ExportList.Text" xml:space="preserve">
-    <value>Export</value>
-  </data>
-  <data name="GitHubLink.Content" xml:space="preserve">
-    <value>GitHub</value>
-  </data>
-  <data name="ImportButton.Text" xml:space="preserve">
-    <value>Import</value>
-  </data>
-  <data name="LightThemeRadio.Content" xml:space="preserve">
-    <value>Light</value>
-  </data>
-  <data name="ListName" xml:space="preserve">
-    <value>List name</value>
-  </data>
-  <data name="LoginMessage" xml:space="preserve">
-    <value>Log into Taskie with Windows Hello. You can turn this off in Settings.</value>
-  </data>
-  <data name="NewList" xml:space="preserve">
-    <value>New list</value>
-  </data>
-  <data name="NewListBtn.Text" xml:space="preserve">
-    <value>New list</value>
-  </data>
-  <data name="RenameList.Text" xml:space="preserve">
-    <value>Rename list</value>
-  </data>
-  <data name="RenameTask.Text" xml:space="preserve">
-    <value>Rename</value>
-  </data>
-  <data name="RestartButton.Text" xml:space="preserve">
-    <value>Restart</value>
-  </data>
-  <data name="RestartWarning.Text" xml:space="preserve">
-    <value>This requires restarting the app.</value>
-  </data>
-  <data name="RestoreHeader.Text" xml:space="preserve">
-    <value>Restore</value>
-  </data>
-  <data name="RestoreText.Text" xml:space="preserve">
-    <value>Import one list (*.json) or a full backup (*.taskie) into the app here. If a list exists, it'll be imported with a (2) next to its name.</value>
-  </data>
-  <data name="SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Search</value>
-  </data>
-  <data name="SecurityCategory" xml:space="preserve">
-    <value>Security</value>
-  </data>
-  <data name="SecurityHeader.Text" xml:space="preserve">
-    <value>Security</value>
-  </data>
-  <data name="SettingsText.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="SystemThemeRadio.Content" xml:space="preserve">
-    <value>System theme</value>
-  </data>
-  <data name="TaskName" xml:space="preserve">
-    <value>Task name</value>
-  </data>
-  <data name="TwitterLink.Content" xml:space="preserve">
-    <value>Twitter</value>
-  </data>
-  <data name="UpgradeText.Text" xml:space="preserve">
-    <value>Upgrade</value>
-  </data>
-  <data name="PromoBannerText.Text" xml:space="preserve">
-    <value>Remove promotional banners</value>
-  </data>
-  <data name="ListLimitText.Text" xml:space="preserve">
-    <value>Remove 3 list limit</value>
-  </data>
-  <data name="PrioritySupportText.Text" xml:space="preserve">
-    <value>Priority support</value>
-  </data>
-  <data name="WinHelloText.Text" xml:space="preserve">
-    <value>Secure login with Windows Hello</value>
-  </data>
-  <data name="IndicatorText.Text" xml:space="preserve">
-    <value>Pro indicator</value>
+    <value>Expört all lists with one click belouw. To expört one list, rite-click it and chooze Expört or uze the three-dot menu after opening it.</value>
   </data>
   <data name="CloseCO.Text" xml:space="preserve">
-    <value>Close the compact overlay to work in this window.</value>
+    <value>Cloze the compact overlay to werk in this windouw.</value>
+  </data>
+  <data name="ExportButton.Text" xml:space="preserve">
+    <value>Expört</value>
+  </data>
+  <data name="ExportList.Text" xml:space="preserve">
+    <value>Expört</value>
+  </data>
+  <data name="ImportButton.Text" xml:space="preserve">
+    <value>Impört</value>
+  </data>
+  <data name="LightThemeRadio.Content" xml:space="preserve">
+    <value>Lite</value>
+  </data>
+  <data name="ListLimitText.Text" xml:space="preserve">
+    <value>Remoov 3 list limit</value>
+  </data>
+  <data name="PrioritySupportText.Text" xml:space="preserve">
+    <value>Pryority settings</value>
+  </data>
+  <data name="ProCancelled" xml:space="preserve">
+    <value>You refünded Pro.</value>
+  </data>
+  <data name="ProCancelledSub" xml:space="preserve">
+    <value>Pro feechers wer block'd.</value>
+  </data>
+  <data name="PromoBannerText.Text" xml:space="preserve">
+    <value>Remoov promotional banners</value>
   </data>
   <data name="protip.Subtitle" xml:space="preserve">
-    <value>Upgrade the app with a small purchase to support me and remove all limits.</value>
+    <value>Upgrade the app with a smaul pürchuss to suppört me and remoov all limits.</value>
   </data>
-  <data name="protip.Title" xml:space="preserve">
-    <value>Liking Taskie?</value>
+  <data name="RestartButton.Text" xml:space="preserve">
+    <value>Reestärt</value>
   </data>
-  <data name="tip1.Subtitle" xml:space="preserve">
-    <value>Add your first list here.</value>
+  <data name="RestartWarning.Text" xml:space="preserve">
+    <value>This requires reestärting the app.</value>
+  </data>
+  <data name="RestoreText.Text" xml:space="preserve">
+    <value>Impört one list (*.json) or a full backup (*.taskie) into the app here. If a list exists, it'll be impört'd with a (2) next to its name.</value>
+  </data>
+  <data name="SearchBox.PlaceholderText" xml:space="preserve">
+    <value>Serch</value>
+  </data>
+  <data name="successfulUpgrade" xml:space="preserve">
+    <value>Suxcessfully upgraded!</value>
+  </data>
+  <data name="SuccessfulUpgradeSub" xml:space="preserve">
+    <value>Taskie Pro wos unlock'd.</value>
+  </data>
+  <data name="SystemThemeRadio.Content" xml:space="preserve">
+    <value>Sistem theme</value>
   </data>
   <data name="tip1.Title" xml:space="preserve">
     <value>Let's start!</value>
   </data>
-  <data name="tipwrongname.Title" xml:space="preserve">
-    <value>You can't do that!</value>
-  </data>
   <data name="tipwrongname.Subtitle" xml:space="preserve">
-    <value>A list with this name already exists.</value>
-  </data>
-  <data name="successfulUpgrade" xml:space="preserve">
-    <value>Successfully upgraded!</value>
-  </data>
-  <data name="SuccessfulUpgradeSub" xml:space="preserve">
-    <value>Taskie Pro was unlocked.</value>
-  </data>
-  <data name="ProCancelled" xml:space="preserve">
-    <value>You refunded Pro.</value>
-  </data>
-  <data name="ProCancelledSub" xml:space="preserve">
-    <value>Pro features were blocked.</value>
-  </data>
-  <data name="Oops" xml:space="preserve">
-    <value>Oops!</value>
-  </data>
-  <data name="Close" xml:space="preserve">
-    <value>Close</value>
+    <value>A list with this name alleddy exists.</value>
   </data>
   <data name="WindowsDefault" xml:space="preserve">
-    <value>Windows default</value>
+    <value>Windows deefault</value>
   </data>
 </root>

--- a/Taskie/Taskie.csproj
+++ b/Taskie/Taskie.csproj
@@ -287,8 +287,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="Strings\en-US\Resources.resw" />
+    <PRIResource Include="Strings\en-US\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
     <PRIResource Include="Strings\pl-PL\Resources.resw" />
+    <PRIResource Include="Strings\en-IN\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
     <None Include="Taskie_TemporaryKey.pfx" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/TaskieLib/Models/Langwaj.cs
+++ b/TaskieLib/Models/Langwaj.cs
@@ -1,0 +1,82 @@
+﻿// Ritten by Jaiganésh; hence uzes Nue English: https://github.com/JUV-Studios/Nue-English.
+
+using System.Collections.Generic;
+using Windows.Globalization;
+using Windows.ApplicationModel.Resources;
+
+namespace TaskieLib.Models
+{
+    public sealed class Langwaj
+    {
+        private static ResourceLoader _rezoarceLoader = ResourceLoader.GetForViewIndependentUse();
+
+        public static string GetLocalized(string key) => _rezoarceLoader.GetString(key);
+
+        public string Tag => Info?.LanguageTag ?? "";
+
+        public Language Info { get; }
+
+        public string Name
+        {
+            get
+            {
+                if (Info == null) return GetLocalized("WindowsDefault");
+
+                if (Info.LanguageTag == "en-IN")
+                {
+                    // English (India) tecknicly; non-naitivs like them need the reförm the moast.
+                    return "Nue English";
+                }
+
+                return Info.NativeName;
+            }
+        }
+
+        private Langwaj(string tag)
+        {
+            if (tag != "") Info = new Language(tag);
+        }
+
+        private static List<Langwaj> _supported;
+
+        public static IReadOnlyList<Langwaj> Supported
+        {
+            get
+            {
+                if (_supported == null)
+                {
+                    var overrideTag = ApplicationLanguages.PrimaryLanguageOverride;
+                    var manifestLangwajes = ApplicationLanguages.ManifestLanguages;
+
+                    _supported = new List<Langwaj>(manifestLangwajes.Count + 1);
+
+                    var winDeefault = new Langwaj("");
+                    _supported.Add(winDeefault);
+                    if (overrideTag == "") { _override = winDeefault; }
+
+                    foreach (var tag in manifestLangwajes)
+                    {
+                        var langwaj = new Langwaj(tag);
+                        _supported.Add(langwaj);
+                        if (tag == overrideTag) _override = langwaj;
+                    }
+                }
+
+                return _supported;
+            }
+        }
+
+        public static Langwaj _override;
+
+        public static Langwaj Override
+        {
+            get => _override;
+
+            set
+            {
+                _override = value;
+                ApplicationLanguages.PrimaryLanguageOverride = _override.Tag;
+            }
+        }
+    }
+}

--- a/TaskieLib/Settings.cs
+++ b/TaskieLib/Settings.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Windows.Storage;
 using Windows.Foundation.Collections;
+using Windows.Globalization;
+using TaskieLib.Models;
+using System.Linq;
 
 namespace TaskieLib
 {

--- a/TaskieLib/TaskieLib.csproj
+++ b/TaskieLib/TaskieLib.csproj
@@ -120,6 +120,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Models\Langwaj.cs" />
     <Compile Include="Models\Task.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />


### PR DESCRIPTION
This puul reqést ads translation for Nue English, a spelling refórm that'll soon be fýnalised and dócumented here: https://github.com/JUV-Studios/Nue-English. Plese don't merj until then.

Since Microsoft dusn't allow [custom langwej tags](https://learn.microsoft.com/fi-fi/windows/apps/publish/publish-your-app/msix/app-package-requirements#list-of-supported-languages), I've chosen tu use en-IN [English (India)] tu store the Nue Clear English translation. I originalli tried en-001 [English (World)][^1] but that automáticli aplýs if yoo hav[^2] eni uther varýeti of English than the default, which is not preférabil for now. In the settings page, where yoo can now overide the áplication langwej, I'v made the entri for en-IN tu display Nue English, rather than English (India).

I'v allso fix'd a spelling error in the existing string set.

~~From[^3] the content of this mesaj and the tranzlated strings, you'd have noticed the strainj usaj of the diaëresis; this is tu mark stress'd short vowels, which uzually forms a nue silable — this is allso the case with two adjacent vowels whare a diaëresis may be uzed. I didn't go with the acute axcënt as uzed in Spanish or Italian, as é in English refërs tu the FACE dïphthöng in French-loanwërds, and udher European langwajes mite uze it differently as well — let's not confuze thoze speekers.~~

Plese revue and share eni sudgestions!

Moast of the chainjes here are too basic tu hav much impáct on reduceing mis-pronúnciation or mis-spelling. That dusn't mene the refórm itsélf is wurthless, alltho there is a decísion tu be made — whether tu only refórm wurds that can cause confusion due tu the use of eronios patterns or tu allso simplify and 'consístentitfy' the spelling sistem.

@shef3r @Aurumaker72 @BreeceW @p3rid0t

[^1]: I cuud try adding additional lojic tu make the sistem faulbäck tu en-US instëd of en-001.
[^2]: 'have' is retain'd with an incorëct magic E, while 'halve' becomes 'hav', or 'haav' with the TRAP-BATH split.
[^3]: 'From' isn't reespëlt as 'Frum' as its strong form is pronounced with eidher with the STR**U**T vowel, mainly in North America, or the L**O**T vowel, mainly in the Commonwealth.